### PR TITLE
Compatibility with latest version of PySB

### DIFF
--- a/earm/albeck_modules.py
+++ b/earm/albeck_modules.py
@@ -307,7 +307,7 @@ def Bax_tetramerizes(bax_active_state='A', rate_scaling_factor=1):
            Bax(s1=2, s2=1, **active_unbound) %
            Bax(s1=3, s2=2, **active_unbound) %
            Bax(s1=4, s2=3, **active_unbound))
-    Rule('Bax_dimerization', active_bax_monomer + active_bax_monomer <> bax2,
+    Rule('Bax_dimerization', active_bax_monomer + active_bax_monomer | bax2,
          Parameter('Bax_dimerization_kf', KF*rate_scaling_factor),
          Parameter('Bax_dimerization_kr', KR))
     # Notes on the parameter values used below:
@@ -321,7 +321,7 @@ def Bax_tetramerizes(bax_active_state='A', rate_scaling_factor=1):
     #  - BNG apparently applies a scaling factor of 2 to the reverse reaction
     #    rate, for reasons we do not entirely understand. The factor of 0.5 is
     #    applied here to make the rate match the original Albeck ODEs.
-    Rule('Bax_tetramerization', bax2 + bax2 <> bax4,
+    Rule('Bax_tetramerization', bax2 + bax2 | bax4,
          Parameter('Bax_tetramerization_kf', 2*KF*rate_scaling_factor),
          Parameter('Bax_tetramerization_kr', 0.5*KR))
 

--- a/earm/shared.py
+++ b/earm/shared.py
@@ -194,7 +194,7 @@ def assemble_pore_spontaneous(subunit, klist):
 
     # Create the pore formation rule
     macros._macro_rule('spontaneous_pore',
-        free_subunit + free_subunit + free_subunit + free_subunit <>
+        free_subunit + free_subunit + free_subunit + free_subunit |
         subunit(s1=1, s2=4) % subunit(s1=2, s2=1) % \
         subunit(s1=3, s2=2) % subunit(s1=4, s2=3),
         klist, ['kf', 'kr'], name_func=pore_rule_name)
@@ -221,7 +221,7 @@ def displace_reversibly(lig1, lig2, target, klist):
     """
 
     return macros._macro_rule('displace',
-         lig1({'bf':None}) + lig2({'bf':1}) % target({'bf':1}) <>
+         lig1({'bf':None}) + lig2({'bf':1}) % target({'bf':1}) |
          lig1({'bf':1}) % target({'bf':1}) + lig2({'bf':None}),
          klist, ['fwd_kf', 'rev_kf'])
 
@@ -239,7 +239,7 @@ def catalyze_convert(sub1, sub2, product, klist, site='bf'):
     macros._verify_sites(sub2, site)
 
     components = macros._macro_rule('bind',
-                             sub1({site: None}) + sub2({site: None}) <>
+                             sub1({site: None}) + sub2({site: None}) |
                              sub1({site: 1}) % sub2({site: 1}),
                              klist[0:2], ['kf', 'kr'])
     components |= macros._macro_rule('convert',
@@ -258,7 +258,7 @@ def one_step_conv(sub1, sub2, product, klist, site='bf'):
     macros._verify_sites(sub2, site)
 
     return macros._macro_rule('convert',
-                       sub1({site: None}) + sub2({site: None}) <> product,
+                       sub1({site: None}) + sub2({site: None}) | product,
                        klist, ['kf', 'kr'])
 
 def pore_bind(subunit, sp_site1, sp_site2, sc_site, size, cargo, c_site,
@@ -342,7 +342,7 @@ def pore_bind(subunit, sp_site1, sp_site2, sc_site, size, cargo, c_site,
     # Create the rules
     name_func = functools.partial(pore_bind_rule_name, size=size)
     components |= macros._macro_rule('pore_bind',
-                              pore_free + cargo_free <> pc_complex,
+                              pore_free + cargo_free | pc_complex,
                               klist[0:2], ['kf', 'kr'],
                               name_func=name_func)
 

--- a/earm/shen_modules.py
+++ b/earm/shen_modules.py
@@ -69,7 +69,7 @@ Stoch. rate constant = Det. rate constant / (N_A * vol)
 # We'll need everything from the pysb core and some macros:
 
 from pysb import *
-from shared import *
+from earm.shared import *
 from pysb.macros import catalyze_one_step_reversible, catalyze_one_step, \
                         synthesize_degrade_table, degrade, equilibrate
 from pysb.util import alias_model_components

--- a/earm/tests/test_albeck_models.py
+++ b/earm/tests/test_albeck_models.py
@@ -86,7 +86,7 @@ def add_caspase8(model):
         model.add_component(kc)
 
         rb = Rule('bind_C8A_BidU_to_C8ABidU',
-             C8(state='A', bf=None) + Bid(state='U', bf=None) <>
+             C8(state='A', bf=None) + Bid(state='U', bf=None) |
              C8(state='A', bf=1) % Bid(state='U', bf=1),
              kf, kr, _export=False)
         rc = Rule('catalyze_C8ABidU_to_C8A_BidT',


### PR DESCRIPTION
I merely swapped <> operator for | in order to recover compatibility with latest version of PySB. I only replaced this occurrences in the code, not replacing them in the comments as I find <> more visually appealing to describe chemical reactions.